### PR TITLE
encode string to bytes object

### DIFF
--- a/trm/ultracam/Utils.py
+++ b/trm/ultracam/Utils.py
@@ -25,7 +25,7 @@ def write_string(fobj, strng):
     strng        -- string to file object opened for binary output
     """
     nchar = len(strng)
-    fobj.write(struct.pack('i' + str(nchar) + 's',nchar, strng))
+    fobj.write(struct.pack('i' + str(nchar) + 's',nchar, strng.encode('utf-8')))
 
 def read_string(fobj, endian=''):
     """


### PR DESCRIPTION
Hi Tom,

Found a minor python 3 compatibility issue here with writing ucm files. The last argument to ```struct.pack``` has to be a ```bytes``` object, which is true for strings in Python 2, but not 3.